### PR TITLE
Fix README.md to properly reference Flask and Flask-SocketIO

### DIFF
--- a/15-ex-pandas-Candlestick-Analysis-Dashboard.md
+++ b/15-ex-pandas-Candlestick-Analysis-Dashboard.md
@@ -1,6 +1,6 @@
 # 15. Project Example: Pandas Candlestick Analysis Dashboard 📈
 
-[<- Back: Project Example: NumPy Image Filter App](./14-ex-Numpy-Streamlit-Image-Filter-App.md) | [Next: Web Development with Django ->](./16-web-development-django.md)
+[<- Back: Project Example: NumPy Image Filter App](./14-ex-Numpy-Streamlit-Image-Filter-App.md) | [Next: Flask Web Framework ->](./16-flask.md)
 
 ## Table of Contents
 
@@ -318,4 +318,4 @@ else: # df_data is empty after processing
 
 ---
 
-[<- Back: Project Example: NumPy Image Filter App](./14-ex-Numpy-Streamlit-Image-Filter-App.md) | [Next: Web Development with Django ->](./16-web-development-django.md)
+[<- Back: Project Example: NumPy Image Filter App](./14-ex-Numpy-Streamlit-Image-Filter-App.md) | [Next: Flask Web Framework ->](./16-flask.md)

--- a/README.md
+++ b/README.md
@@ -88,15 +88,22 @@ This collection of notes provides a comprehensive guide to understanding Python,
     - Time-series data processing
     - Interactive financial dashboards
     
-16. **[Web Development with Django](./16-web-development-django.md)** 🌐
-    - Django framework fundamentals
-    - Building web applications
-    - Database integration with ORM
+16. **[Flask Web Framework](./16-flask.md)** 🌐
+    - Lightweight web application development
+    - Routing and request handling
+    - Templates and application structure
+    - Sub-topics:
+      - [Flask Beginner](./16a-flask-beginner.md)
+      - [Flask Intermediate](./16b-flask-intermediate.md)
 
-17. **[API Development with FastAPI](./17-api-development-fastapi.md)** 🚄
-    - RESTful API design principles
-    - FastAPI implementation
-    - API documentation and testing
+17. **[Flask-SocketIO: Real-time Web Applications](./17-flask-socketio.md)** 🔌
+    - WebSocket integration with Flask
+    - Real-time bidirectional communication
+    - Building interactive dashboards
+    - Sub-topics:
+      - [Core Application Structure](./17a-core-application.md)
+      - [Data Processing and Visualization](./17b-data-processing.md)
+      - [Core Terms and Concepts](./17c-core-terms.md)
 ---
 
 _(These notes are designed for beginners to intermediate Python developers and assume basic programming knowledge. Each topic builds on the previous ones, creating a comprehensive learning journey.)_


### PR DESCRIPTION
This PR fixes the README.md and note 15 to correctly reference Flask and Flask-SocketIO topics instead of Django and FastAPI, which were incorrectly added previously.

Changes:
1. Updated README.md with proper references to Flask Web Framework (topic 16) and Flask-SocketIO (topic 17) to match the actual files in the repository
2. Updated the navigation links in note 15 to point to the Flask topic
3. Added proper descriptions for Flask and Flask-SocketIO topics in the README.md
4. Added sub-topic links under both Flask and Flask-SocketIO in the README.md

The content now accurately reflects the actual files that are already implemented in the repository.